### PR TITLE
Fix a division by zero bug

### DIFF
--- a/Regression/Regression.php
+++ b/Regression/Regression.php
@@ -168,7 +168,7 @@ class Regression
                 ->getEntry(0, 0);
 
         $this->SSTOScalar = $this->SSRScalar + $this->SSEScalar;
-        $this->RSquare = $this->SSRScalar / $this->SSTOScalar;
+        $this->RSquare = $this->SSTOScalar == 0 ? 1 : $this->SSRScalar / $this->SSTOScalar;
         $this->F = ($this->SSRScalar / $dfModel) / ($this->SSEScalar / $dfResidual);
         
         //MSE = SSE/(df)


### PR DESCRIPTION
This fixes a bug when all the dependent variables are the same. I'm not a mathmatician in any way, so if you have any better solutions I'd gladly hear them, but this (from a development point of view..) fixes the issue we had when all dependent values were the same. It would cause a division by zero.
